### PR TITLE
Move SECRET_KEY to environment variable

### DIFF
--- a/backend/bird_proj/settings.py
+++ b/backend/bird_proj/settings.py
@@ -17,8 +17,6 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 from pathlib import Path
 
-# import os
-
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
 
@@ -27,7 +25,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.0/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-q*+slm*q@rxv!n-d6vv51krhq!(mtee24dt=0$hvwp0%vedpf$"
+SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-fallback-for-local-dev-only")
 
 # SECURITY WARNING: don't run with debug turned on in production!
 if os.environ["env"] == "prod":


### PR DESCRIPTION
- Read SECRET_KEY from environment instead of hardcoded value
- Falls back to development key for local testing
- Improves security by keeping production key out of source control