### PR TITLE
fix: update Django settings for new VPS deployment

### DIFF
--- a/backend/bird_proj/settings.py
+++ b/backend/bird_proj/settings.py
@@ -31,16 +31,12 @@ SECRET_KEY = os.environ.get("SECRET_KEY", "django-insecure-fallback-for-local-de
 if os.environ["env"] == "prod":
     DEBUG = False
     ALLOWED_HOSTS = [
-        "hellobirdie.2masterlight.site",
-        "hellobirdy.2masterlight.site",
         "hellobirdie.2masterlight.com",
         "www.hellobirdie.2masterlight.com",
         "hellobirdy.2masterlight.com",
         "www.hellobirdy.2masterlight.com",
     ]
     CSRF_TRUSTED_ORIGINS = [
-        "https://hellobirdie.2masterlight.site",
-        "https://hellobirdy.2masterlight.site",
         "https://hellobirdie.2masterlight.com",
         "https://www.hellobirdie.2masterlight.com",
         "https://hellobirdy.2masterlight.com",


### PR DESCRIPTION
- Remove legacy .site domain references
- Keep only .com domains in ALLOWED_HOSTS and CSRF_TRUSTED_ORIGINS
- SECRET_KEY already configured to read from environment